### PR TITLE
Remove random from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 flask
-random
 english_words


### PR DESCRIPTION
Random is included in the Python standard library meaning that it is already installed with Python. There is also no package called random on PyPI, so it wont install anything anyway.